### PR TITLE
Delete redundant slash

### DIFF
--- a/framework/classes/Code_Alchemy/APIs/Envato/Envato_API_Client.php
+++ b/framework/classes/Code_Alchemy/APIs/Envato/Envato_API_Client.php
@@ -15,7 +15,7 @@ class Envato_API_Client extends Alchemist {
     /**
      * @var string Base URL for calling Envato API
      */
-    private $baseUrl = 'https://api.envato.com/v1/';
+    private $baseUrl = 'https://api.envato.com/v1';
 
     /**
      * @var string Bearer Token


### PR DESCRIPTION
Delete redundant slash because :
https://api.envato.com/v1/ . /discovery/search/search/item?$parameters = https://api.envato.com/v1//discovery/search/search/item?$parameters  and it makes wrong URL